### PR TITLE
Initial attempt at better booking flow

### DIFF
--- a/App.js
+++ b/App.js
@@ -31,7 +31,6 @@ const StudyRoomStack = StackNavigator({
   ClassroomView: { screen: ClassroomView },
   BookingWebView: { screen: BookingWebView },
   ClassroomAvailabilityView: { screen: ClassroomAvailabilityView },
-
 },
 {
   initialRouteName: 'StudyRoomsContainer',

--- a/app/components/TimeRangeCard.js
+++ b/app/components/TimeRangeCard.js
@@ -1,0 +1,170 @@
+import React, { Component } from 'react';
+import {
+  Text, View, TouchableOpacity, StyleSheet
+} from 'react-native';
+
+const intervals = {
+  '12:00-1:00am': ['12:00', '12:30'],
+  '1:00-2:00am': ['1:00', '1:30'],
+  '2:00-3:00am': ['2:00', '2:30'],
+  '3:00-4:00am': ['3:00', '3:30'],
+  '4:00-5:00am': ['4:00', '4:30'],
+  '5:00-6:00am': ['5:00', '5:30'],
+  '6:00-7:00am': ['6:00', '6:30'],
+  '7:00-8:00am': ['7:00', '7:30'],
+  '8:00-9:00am': ['8:00', '8:30'],
+  '9:00-10:00am': ['9:00', '9:30'],
+  '10:00-11:00am': ['10:00', '10:30'],
+  '11:00-12:00pm': ['11:00', '11:30'],
+  '12:00-1:00pm': ['12:00', '12:30'],
+  '1:00-2:00pm': ['1:00', '1:30'],
+  '2:00-3:00pm': ['2:00', '2:30'],
+  '3:00-4:00pm': ['3:00', '3:30'],
+  '4:00-5:00pm': ['4:00', '4:30'],
+  '5:00-6:00pm': ['5:00', '5:30'],
+  '6:00-7:00pm': ['6:00', '6:30'],
+  '7:00-8:00pm': ['7:00', '7:30'],
+  '8:00-9:00pm': ['8:00', '8:30'],
+  '9:00-10:00pm': ['9:00', '9:30'],
+  '10:00-11:00pm': ['10:00', '10:30'],
+  '11:00-12:00am': ['11:00', '11:30'],
+};
+
+export default class TimeRangeCard extends Component {
+  constructor(props) {
+    super(props);
+    this.state = {
+      collapsed: true,
+    };
+  }
+
+  handleExpandPress = () => {
+    const { collapsed } = this.state;
+    if (collapsed) {
+      this.setState({ collapsed: false });
+    } else {
+      this.setState({ collapsed: true });
+    }
+  }
+
+  handleSelectRoom = (range) => {
+    this.setState(prevState => ({
+      collapsed: !prevState.collapsed
+    }));
+  }
+
+  showExpandedCell = (title) => {
+    const { collapsed } = this.state;
+    if (!collapsed) {
+      return (
+        <View style={styles.row}>
+          <TouchableOpacity disabled={this.props.hour.length === 0} style={this.props.hour.length > 0 ? styles.button : styles.buttonDisabled}>
+            <Text style={styles.text}>
+              {' '}
+              {intervals[title][0]}
+            </Text>
+          </TouchableOpacity>
+          <TouchableOpacity disabled={this.props.half.length === 0} style={this.props.half.length > 0 ? styles.button : styles.buttonDisabled}>
+            <Text style={styles.text}>
+              {' '}
+              {intervals[title][1]}
+            </Text>
+          </TouchableOpacity>
+        </View>
+
+      );
+    }
+    return null;
+  }
+
+  render() {
+    const { title, available } = this.props;
+    const { collapsed } = this.state;
+    return (
+      <TouchableOpacity
+        onPress={() => this.handleSelectRoom(title)}
+      >
+        <View style={collapsed ? styles.cell : styles.expandedCell}>
+          <Text style={[styles.text]}>
+            {title}
+          </Text>
+          <Text style={styles.smallText}>
+            {' '}
+            {`${available.length} Available`}
+            {' '}
+          </Text>
+          {this.showExpandedCell(title)}
+        </View>
+      </TouchableOpacity>
+    );
+  }
+}
+
+const text = {
+  fontFamily: 'System',
+  fontSize: 16,
+  fontWeight: '300',
+  fontStyle: 'normal',
+  letterSpacing: 1.92,
+  color: 'black',
+  paddingBottom: 3,
+};
+
+const cell = {
+  flexDirection: 'column',
+  justifyContent: 'space-around',
+  alignItems: 'center',
+  height: 60,
+  width: '95%',
+  padding: 10,
+  marginTop: 4,
+  marginBottom: 4,
+  borderRadius: 5,
+  alignSelf: 'center',
+  backgroundColor: '#FFF',
+  elevation: 2,
+  shadowColor: 'rgba(0, 0, 0, 0.5)',
+  shadowOffset: {
+    width: 0.5,
+    height: 0.5
+  },
+  shadowRadius: 1,
+  shadowOpacity: 0.8,
+};
+
+const button = {
+  borderRadius: 7,
+  justifyContent: 'center',
+  alignItems: 'center',
+  borderColor: 'black',
+  borderWidth: 1,
+  minWidth: 60,
+  marginLeft: 5,
+  marginRight: 5,
+};
+
+const styles = StyleSheet.create({
+  text,
+  cell,
+  button,
+  expandedCell: {
+    ...cell,
+    height: 100,
+  },
+
+  smallText: {
+    ...text,
+    fontSize: 12,
+
+  },
+
+  row: {
+    flexDirection: 'row',
+  },
+
+  buttonDisabled: {
+    ...button,
+    opacity: 0.3
+  }
+
+});

--- a/app/components/TimeRangeCard.js
+++ b/app/components/TimeRangeCard.js
@@ -15,7 +15,7 @@ const intervals = {
   '8:00-9:00am': ['8:00', '8:30'],
   '9:00-10:00am': ['9:00', '9:30'],
   '10:00-11:00am': ['10:00', '10:30'],
-  '11:00-12:00pm': ['11:00', '11:30'],
+  '11:00am-12:00pm': ['11:00', '11:30'],
   '12:00-1:00pm': ['12:00', '12:30'],
   '1:00-2:00pm': ['1:00', '1:30'],
   '2:00-3:00pm': ['2:00', '2:30'],
@@ -27,7 +27,7 @@ const intervals = {
   '8:00-9:00pm': ['8:00', '8:30'],
   '9:00-10:00pm': ['9:00', '9:30'],
   '10:00-11:00pm': ['10:00', '10:30'],
-  '11:00-12:00am': ['11:00', '11:30'],
+  '11:00pm-midnight': ['11:00', '11:30'],
 };
 
 export default class TimeRangeCard extends Component {
@@ -54,17 +54,24 @@ export default class TimeRangeCard extends Component {
   }
 
   showExpandedCell = (title) => {
+    const { hour, half } = this.props;
     const { collapsed } = this.state;
     if (!collapsed) {
       return (
         <View style={styles.row}>
-          <TouchableOpacity disabled={this.props.hour.length === 0} style={this.props.hour.length > 0 ? styles.button : styles.buttonDisabled}>
+          <TouchableOpacity
+            disabled={hour.length === 0}
+            style={hour.length > 0 ? styles.button : styles.buttonDisabled}
+          >
             <Text style={styles.text}>
               {' '}
               {intervals[title][0]}
             </Text>
           </TouchableOpacity>
-          <TouchableOpacity disabled={this.props.half.length === 0} style={this.props.half.length > 0 ? styles.button : styles.buttonDisabled}>
+          <TouchableOpacity
+            disabled={half.length === 0}
+            style={half.length > 0 ? styles.button : styles.buttonDisabled}
+          >
             <Text style={styles.text}>
               {' '}
               {intervals[title][1]}

--- a/app/components/TimeRangeCard.js
+++ b/app/components/TimeRangeCard.js
@@ -2,6 +2,7 @@ import React, { Component } from 'react';
 import {
   Text, View, TouchableOpacity, StyleSheet
 } from 'react-native';
+import { withNavigation } from 'react-navigation';
 
 const intervals = {
   '12:00-1:00am': ['12:00', '12:30'],
@@ -30,7 +31,7 @@ const intervals = {
   '11:00pm-midnight': ['11:00', '11:30'],
 };
 
-export default class TimeRangeCard extends Component {
+class TimeRangeCard extends Component {
   constructor(props) {
     super(props);
     this.state = {
@@ -54,6 +55,7 @@ export default class TimeRangeCard extends Component {
   }
 
   showExpandedCell = (title) => {
+    const { navigate } = this.props.navigation;
     const { hour, half } = this.props;
     const { collapsed } = this.state;
     if (!collapsed) {
@@ -62,6 +64,9 @@ export default class TimeRangeCard extends Component {
           <TouchableOpacity
             disabled={hour.length === 0}
             style={hour.length > 0 ? styles.button : styles.buttonDisabled}
+            onPress={() => navigate('StudyRoomReserve', {
+              rooms: hour.sort((a, b) => (a.details > b.details) ? 1 : -1)
+            })}
           >
             <Text style={styles.text}>
               {' '}
@@ -71,6 +76,9 @@ export default class TimeRangeCard extends Component {
           <TouchableOpacity
             disabled={half.length === 0}
             style={half.length > 0 ? styles.button : styles.buttonDisabled}
+            onPress={() => navigate('StudyRoomReserve', {
+              rooms: half.sort((a, b) => (a.details > b.details) ? 1 : -1)
+            })}
           >
             <Text style={styles.text}>
               {' '}
@@ -175,3 +183,5 @@ const styles = StyleSheet.create({
   }
 
 });
+
+export default withNavigation(TimeRangeCard)

--- a/app/screens/StudyRoom/StudyRoom.js
+++ b/app/screens/StudyRoom/StudyRoom.js
@@ -9,6 +9,7 @@ import FloatingSegment from '../../components/FloatingSegment';
 import ShadowButton from '../../components/ShadowButton';
 import BookingCard from '../../components/BookingCard';
 import ClassroomBuildingCard from '../../components/ClassroomBuildingCard';
+import StudyRoomsPreview from './StudyRoomsPreview';
 
 const namePairs = {
   sproulstudy: 'Sproul Study Rooms',
@@ -79,62 +80,13 @@ export default class StudyRoomList extends Component {
       visible, currentLocation
     } = this.state;
     const {
-      navigation, filterData, hillDataFound, librariesDataFound, availClassroomDataFound, loading, getStudyRooms
+      navigation, filterData, librariesDataFound, availClassroomDataFound, loading, getStudyRooms,
     } = this.props;
-
-    const buildings = {
-      count: 3,
-      items: [
-        {
-          name: 'boelter',
-          available: 37,
-          rooms: [
-            'A44',
-            'A48',
-            'A40',
-            'A41',
-          ],
-        },
-        {
-          name: 'haines',
-          available: 18,
-          rooms: [
-            'A44',
-            'A48',
-            'A40',
-            'A41',
-          ],
-        },
-        {
-          name: 'franz',
-          available: 24,
-          rooms: [
-            'A44',
-            'A48',
-            'A40',
-            'A41',
-          ],
-        },
-      ]
-    };
 
     let listData;
     switch (currentLocation) {
       case 'Hill':
-        listData = hillDataFound.length > 0 ? (
-          <FlatList
-            data={hillDataFound}
-            extraData={hillDataFound}
-            renderItem={({ item }) => this.renderRow(item)}
-            keyExtractor={(item, index) => index.toString()}
-            style={styles.list}
-          />
-        ) : (
-          <View style={styles.empty}>
-            <Text style={titleText}> No rooms available </Text>
-            <ShadowButton title="Change Time" select={this.handleModal} />
-          </View>
-        );
+        listData = <StudyRoomsPreview />;
         break;
       case 'Libraries':
         listData = librariesDataFound.length > 0 ? (
@@ -167,9 +119,6 @@ export default class StudyRoomList extends Component {
             <ShadowButton title="Change Time" select={this.handleModal} />
           </View>
         );
-
-        // TODO
-        // listData =
         break;
       default:
         listData = (
@@ -188,12 +137,13 @@ export default class StudyRoomList extends Component {
             sortData={this.sortData}
             handleModal={this.handleModal}
             filterData={filterData}
+            currentLocation={currentLocation}
           />
           <FloatingSegment setCategory={this.setLocation} selected={currentLocation} titles={['Hill', 'Libraries', 'Classrooms']} />
           {loading ? <ActivityIndicator style={styles.animation} size="large" color="#108BF8" /> : null}
           {listData}
           {visible ? (
-            <StudyRoomModal handleModal={this.handleModal} getStudyRooms={getStudyRooms} currentLocation={this.state.currentLocation} />
+            <StudyRoomModal handleModal={this.handleModal} getStudyRooms={getStudyRooms} currentLocation={currentLocation} />
           ) : null}
         </SafeAreaView>
       </TouchableWithoutFeedback>

--- a/app/screens/StudyRoom/StudyRoom.js
+++ b/app/screens/StudyRoom/StudyRoom.js
@@ -81,12 +81,20 @@ export default class StudyRoomList extends Component {
     } = this.state;
     const {
       navigation, filterData, librariesDataFound, availClassroomDataFound, loading, getStudyRooms,
+      available, hillDataFound,
     } = this.props;
 
     let listData;
     switch (currentLocation) {
       case 'Hill':
-        listData = <StudyRoomsPreview />;
+        listData = hillDataFound.length > 0 ? (
+          <StudyRoomsPreview available={available} listOfRooms={hillDataFound} />
+        ) : (
+          <View style={styles.empty}>
+            <Text style={titleText}> No rooms available </Text>
+            <ShadowButton title="Change Time" select={this.handleModal} />
+          </View>
+        );
         break;
       case 'Libraries':
         listData = librariesDataFound.length > 0 ? (

--- a/app/screens/StudyRoom/StudyRoom.js
+++ b/app/screens/StudyRoom/StudyRoom.js
@@ -88,7 +88,7 @@ export default class StudyRoomList extends Component {
     let listData;
     switch (currentLocation) {
       case 'Hill':
-        listData = hillDataFound.length > 0 ? (
+        listData = hillDataFound.length > 0 && Object.keys(available).length !== 0 ? (
           <StudyRoomsPreview available={available} listOfRooms={hillDataFound} />
         ) : (
           <View style={styles.empty}>

--- a/app/screens/StudyRoom/StudyRoom.js
+++ b/app/screens/StudyRoom/StudyRoom.js
@@ -98,11 +98,11 @@ export default class StudyRoomList extends Component {
             style={styles.list}
           />
         ) : (
-          <View style={styles.empty}>
-            <Text style={titleText}> No rooms available </Text>
-            <ShadowButton title="Change Time" select={this.handleModal} />
-          </View>
-        );
+            <View style={styles.empty}>
+              <Text style={titleText}> No rooms available </Text>
+              <ShadowButton title="Change Time" select={this.handleModal} />
+            </View>
+          );
         break;
       case 'Classrooms':
         listData = availClassroomDataFound.rowCount > 0 ? (
@@ -114,11 +114,11 @@ export default class StudyRoomList extends Component {
             style={styles.list}
           />
         ) : (
-          <View style={styles.empty}>
-            <Text style={titleText}> No rooms available </Text>
-            <ShadowButton title="Change Time" select={this.handleModal} />
-          </View>
-        );
+            <View style={styles.empty}>
+              <Text style={titleText}> No rooms available </Text>
+              <ShadowButton title="Change Time" select={this.handleModal} />
+            </View>
+          );
         break;
       default:
         listData = (
@@ -129,6 +129,8 @@ export default class StudyRoomList extends Component {
         );
     }
 
+    const floatComponent = <FloatingSegment setCategory={this.setLocation} selected={currentLocation} titles={['Hill', 'Libraries', 'Classrooms']} />;
+
     return (
       <TouchableWithoutFeedback onPress={() => Keyboard.dismiss()}>
         <SafeAreaView style={styles.container}>
@@ -138,8 +140,8 @@ export default class StudyRoomList extends Component {
             handleModal={this.handleModal}
             filterData={filterData}
             currentLocation={currentLocation}
+            floatComponent={floatComponent}
           />
-          <FloatingSegment setCategory={this.setLocation} selected={currentLocation} titles={['Hill', 'Libraries', 'Classrooms']} />
           {loading ? <ActivityIndicator style={styles.animation} size="large" color="#108BF8" /> : null}
           {listData}
           {visible ? (

--- a/app/screens/StudyRoom/StudyRoom.js
+++ b/app/screens/StudyRoom/StudyRoom.js
@@ -1,6 +1,6 @@
 import React, { Component } from 'react';
 import {
-  Text, View, TouchableOpacity, StyleSheet, Image, SafeAreaView, FlatList, ActivityIndicator,
+  Text, View, StyleSheet, SafeAreaView, FlatList, ActivityIndicator,
   TouchableWithoutFeedback, Keyboard,
 } from 'react-native';
 import StudyRoomHeader from './StudyRoomHeader';
@@ -11,41 +11,42 @@ import BookingCard from '../../components/BookingCard';
 import ClassroomBuildingCard from '../../components/ClassroomBuildingCard';
 import StudyRoomsPreview from './StudyRoomsPreview';
 
-const namePairs = {
-  sproulstudy: 'Sproul Study Rooms',
-  sproulmusic: 'Sproul Music Rooms',
-  deneve: 'De Neve Meeting Rooms',
-  rieber: 'Rieber Study Rooms',
-  music: 'Rieber Music Rooms',
-  hedrick: 'The Study at Hedrick',
-  hedrickstudy: 'Hedrick Study Rooms',
-  hedrickmusic: 'Hedrick Music Rooms',
-  movement: 'Hedrick Movement Studio',
-};
+// const namePairs = {
+//   sproulstudy: 'Sproul Study Rooms',
+//   sproulmusic: 'Sproul Music Rooms',
+//   deneve: 'De Neve Meeting Rooms',
+//   rieber: 'Rieber Study Rooms',
+//   music: 'Rieber Music Rooms',
+//   hedrick: 'The Study at Hedrick',
+//   hedrickstudy: 'Hedrick Study Rooms',
+//   hedrickmusic: 'Hedrick Music Rooms',
+//   movement: 'Hedrick Movement Studio',
+// };
 
-const sproulstudy = require('../../../assets/Studyrooms/sproulstudy.jpg');
-const sproulmusic = require('../../../assets/Studyrooms/sproulmusic.jpg');
-const deneve = require('../../../assets/Studyrooms/deneve.jpg');
-const rieber = require('../../../assets/Studyrooms/rieber.jpg');
-const hedrick = require('../../../assets/Studyrooms/hedrickstudy.jpg');
-const hedrickmusic = require('../../../assets/Studyrooms/hedrickmusic.jpg');
-const music = require('../../../assets/Studyrooms/music.jpg');
-const hedrickstudy = require('../../../assets/Studyrooms/hedrick.jpg');
-const movement = require('../../../assets/Studyrooms/movement.jpg');
+// const sproulstudy = require('../../../assets/Studyrooms/sproulstudy.jpg');
+// const sproulmusic = require('../../../assets/Studyrooms/sproulmusic.jpg');
+// const deneve = require('../../../assets/Studyrooms/deneve.jpg');
+// const rieber = require('../../../assets/Studyrooms/rieber.jpg');
+// const hedrick = require('../../../assets/Studyrooms/hedrickstudy.jpg');
+// const hedrickmusic = require('../../../assets/Studyrooms/hedrickmusic.jpg');
+// const music = require('../../../assets/Studyrooms/music.jpg');
+// const hedrickstudy = require('../../../assets/Studyrooms/hedrick.jpg');
+// const movement = require('../../../assets/Studyrooms/movement.jpg');
 
-const imagePairs = {
-  sproulmusic,
-  sproulstudy,
-  deneve,
-  rieber,
-  hedrick,
-  hedrickmusic,
-  music,
-  hedrickstudy,
-  movement
-};
+// const imagePairs = {
+//   sproulmusic,
+//   sproulstudy,
+//   deneve,
+//   rieber,
+//   hedrick,
+//   hedrickmusic,
+//   music,
+//   hedrickstudy,
+//   movement
+// };
 
 export default class StudyRoomList extends Component {
+  // eslint-disable-next-line react/sort-comp
   static navigationOptions = {
     header: () => { }
   }
@@ -106,11 +107,11 @@ export default class StudyRoomList extends Component {
             style={styles.list}
           />
         ) : (
-            <View style={styles.empty}>
-              <Text style={titleText}> No rooms available </Text>
-              <ShadowButton title="Change Time" select={this.handleModal} />
-            </View>
-          );
+          <View style={styles.empty}>
+            <Text style={titleText}> No rooms available </Text>
+            <ShadowButton title="Change Time" select={this.handleModal} />
+          </View>
+        );
         break;
       case 'Classrooms':
         listData = availClassroomDataFound.rowCount > 0 ? (
@@ -122,11 +123,11 @@ export default class StudyRoomList extends Component {
             style={styles.list}
           />
         ) : (
-            <View style={styles.empty}>
-              <Text style={titleText}> No rooms available </Text>
-              <ShadowButton title="Change Time" select={this.handleModal} />
-            </View>
-          );
+          <View style={styles.empty}>
+            <Text style={titleText}> No rooms available </Text>
+            <ShadowButton title="Change Time" select={this.handleModal} />
+          </View>
+        );
         break;
       default:
         listData = (
@@ -153,7 +154,11 @@ export default class StudyRoomList extends Component {
           {loading ? <ActivityIndicator style={styles.animation} size="large" color="#108BF8" /> : null}
           {listData}
           {visible ? (
-            <StudyRoomModal handleModal={this.handleModal} getStudyRooms={getStudyRooms} currentLocation={currentLocation} />
+            <StudyRoomModal
+              handleModal={this.handleModal}
+              getStudyRooms={getStudyRooms}
+              currentLocation={currentLocation}
+            />
           ) : null}
         </SafeAreaView>
       </TouchableWithoutFeedback>

--- a/app/screens/StudyRoom/StudyRoomHeader.js
+++ b/app/screens/StudyRoom/StudyRoomHeader.js
@@ -30,9 +30,10 @@ class StudyRoomHeader extends Component {
   }
 
   render() {
-    const { date, time, handleModal } = this.props;
+    const { date, time, handleModal, currentLocation } = this.props;
     const month = monthPairs[date.substring(0, 2)];
     const day = date.substring(3, 5);
+
     return (
       <View style={styles.topBar}>
         <View style={styles.bar}>
@@ -42,22 +43,28 @@ class StudyRoomHeader extends Component {
           <View style={styles.leftViewAbs}>
             <Text style={styles.searchText}>
               {' '}
-              {date !== '' || time !== '' ? `${month} ${day} ${time}` : ''}
+              {date !== '' || time !== '' ? `${month} ${day} ${currentLocation !== 'Hill' ? time : ''}` : ''}
               {' '}
             </Text>
           </View>
         </View>
-        <Search
-          data={fakeVal} // this should be an API call or huge list eventually
-          defaultValue=""
-          placeholder="Search places to reserve..."
-          onChangeText={text => this.handleInput(text)}
-          style={[styles.searchContainer, styles.input]}
-          inputContainerStyle={[styles.inputContainer]}
-          renderItem={() => (
-            <TouchableOpacity onPress={() => null} />
-          )}
-        />
+        {/* TOOD: Switch order of 3 selector and the search bar so it doesnt look weird */}
+        {
+          currentLocation !== 'Hill'
+          && (
+          <Search
+            data={fakeVal} // this should be an API call or huge list eventually
+            defaultValue=""
+            placeholder="Search places to reserve..."
+            onChangeText={text => this.handleInput(text)}
+            style={[styles.searchContainer, styles.input]}
+            inputContainerStyle={[styles.inputContainer]}
+            renderItem={() => (
+              <TouchableOpacity onPress={() => null} />
+            )}
+          />
+          )
+        }
       </View>
     );
   }
@@ -76,7 +83,8 @@ const titleText = {
   color: '#108BF8',
   width: '80%',
   padding: 5,
-  textAlign: 'center'
+  textAlign: 'center',
+  alignItems: 'center'
 };
 
 const styles = StyleSheet.create({

--- a/app/screens/StudyRoom/StudyRoomHeader.js
+++ b/app/screens/StudyRoom/StudyRoomHeader.js
@@ -30,17 +30,18 @@ class StudyRoomHeader extends Component {
   }
 
   render() {
-    const { date, time, handleModal, currentLocation } = this.props;
+    const { date, time, handleModal, currentLocation, floatComponent } = this.props;
     const month = monthPairs[date.substring(0, 2)];
     const day = date.substring(3, 5);
 
     return (
-      <View style={styles.topBar}>
+      <View style={currentLocation !== 'Hill' ? styles.topBar : styles.topShortBar}>
         <View style={styles.bar}>
           <TouchableOpacity style={styles.rightButtonAbs} onPress={() => handleModal()}>
+            {/* TODO: Change source icon for 'Hill' to be a calendar instead */}
             <Image source={clockIcon} style={{ width: 25, height: 25 }} />
           </TouchableOpacity>
-          <View style={styles.leftViewAbs}>
+          <View>
             <Text style={styles.searchText}>
               {' '}
               {date !== '' || time !== '' ? `${month} ${day} ${currentLocation !== 'Hill' ? time : ''}` : ''}
@@ -48,21 +49,21 @@ class StudyRoomHeader extends Component {
             </Text>
           </View>
         </View>
-        {/* TOOD: Switch order of 3 selector and the search bar so it doesnt look weird */}
+        {floatComponent}
         {
           currentLocation !== 'Hill'
           && (
-          <Search
-            data={fakeVal} // this should be an API call or huge list eventually
-            defaultValue=""
-            placeholder="Search places to reserve..."
-            onChangeText={text => this.handleInput(text)}
-            style={[styles.searchContainer, styles.input]}
-            inputContainerStyle={[styles.inputContainer]}
-            renderItem={() => (
-              <TouchableOpacity onPress={() => null} />
-            )}
-          />
+            <Search
+              data={fakeVal} // this should be an API call or huge list eventually
+              defaultValue=""
+              placeholder="Search places to reserve..."
+              onChangeText={text => this.handleInput(text)}
+              style={[styles.searchContainer, styles.input]}
+              inputContainerStyle={[styles.inputContainer]}
+              renderItem={() => (
+                <TouchableOpacity onPress={() => null} />
+              )}
+            />
           )
         }
       </View>
@@ -99,6 +100,11 @@ const styles = StyleSheet.create({
     textAlign: 'left',
   },
   topBar: {
+    alignItems: 'center',
+    width: '100%',
+    height: 120
+  },
+  topShortBar: {
     alignItems: 'center',
     width: '100%',
     height: 100

--- a/app/screens/StudyRoom/StudyRoomReserve.js
+++ b/app/screens/StudyRoom/StudyRoomReserve.js
@@ -118,7 +118,7 @@ export default class StudyRoomReserve extends Component {
         </View>
         <FloatingSegment setCategory={this.setDuration} selected={duration} titles={['1 hour', '2 hours']} />
         <FlatList
-          data={rooms.available}
+          data={rooms}
           extraData={this.state}
           renderItem={({ item }) => this.renderList(item)}
           keyExtractor={(item, index) => index.toString()}

--- a/app/screens/StudyRoom/StudyRoomsContainer.js
+++ b/app/screens/StudyRoom/StudyRoomsContainer.js
@@ -22,7 +22,6 @@ const namePairs = {
   movement: 'Hedrick Movement Studio',
 };
 
-
 class StudyRoomsContainer extends Component {
   static navigationOptions = {
     header: () => { }
@@ -37,7 +36,6 @@ class StudyRoomsContainer extends Component {
     };
     this.getStudyRooms = this.getStudyRooms.bind(this);
   }
-
 
   componentDidMount() {
     const setting = new Date();
@@ -70,6 +68,7 @@ class StudyRoomsContainer extends Component {
         styledTime = `${hourString + styledTime.slice(2)}AM`;
       }
     }
+
     changeTimeAction(styledTime);
     let chosen = setting;
     let dd = chosen.getDate();
@@ -94,7 +93,7 @@ class StudyRoomsContainer extends Component {
   }
 
   getStudyRooms() {
-    this.getHillStudyRooms();
+    // this.getHillStudyRooms();
     this.getLibraryStudyRooms();
     this.getAvailableClassrooms();
   }
@@ -464,7 +463,7 @@ class StudyRoomsContainer extends Component {
     const { navigation } = this.props;
     return (
       <StudyRoomList
-        hillDataFound={hillData}
+        // hillDataFound={hillData}
         librariesDataFound={librariesData}
         availClassroomDataFound={availClassroomData}
         filterData={this.filterData}

--- a/app/screens/StudyRoom/StudyRoomsContainer.js
+++ b/app/screens/StudyRoom/StudyRoomsContainer.js
@@ -30,6 +30,7 @@ class StudyRoomsContainer extends Component {
   constructor(props) {
     super(props);
     this.state = {
+      availableHill: {},
       hillData: [],
       librariesData: [],
       loading: true,
@@ -93,61 +94,40 @@ class StudyRoomsContainer extends Component {
   }
 
   getStudyRooms() {
-    // this.getHillStudyRooms();
+    this.getHillStudyRooms();
     this.getLibraryStudyRooms();
     this.getAvailableClassrooms();
   }
 
   async getHillStudyRooms() {
-    let temp; let month; let day; let
-      year;
     let appendedURL = '';
-    const { date, time, loadHillData: loadHillDataAction } = this.props;
+    const { date } = this.props;
     if (date.length > 0) {
-      month = date.substring(0, 2);
-      day = date.substring(3, 5);
-      year = date.substring(date.length - 4);
-      if (time.length === 0) {
-        appendedURL = `?date=${year}-${month}-${day}`;
-      }
+      const month = date.substring(0, 2);
+      const day = date.substring(3, 5);
+      const year = date.substring(date.length - 4);
+      appendedURL = `?date=${year}-${month}-${day}`;
     }
-    if (time.length > 0) {
-      let time2 = time;
-      if (!time2.includes(':')) {
-        time2 = `${time2.slice(0, 2)}:${time2.slice(2)}`;
-      }
-      const splitTime = time2.split(':');
-      const yearInt = parseInt(year, 10);
-      const monthInt = parseInt(month, 10);
-      const dayInt = parseInt(day, 10);
-      let hourInt = parseInt(splitTime[0], 10);
-      const minuteInt = parseInt(splitTime[1].substring(0, 2), 10);
-      const amPm = splitTime[1].substring(splitTime[1].length - 2);
-      if (amPm === 'PM') {
-        if (hourInt !== 12) {
-          hourInt += 12;
-        }
-      }
-      if (hourInt === 12 && amPm === 'AM') {
-        hourInt = 0;
-      }
-      const newDate = new Date(yearInt, monthInt - 1, dayInt, hourInt, minuteInt, 0, 0);
-
-      const seconds = newDate.getTime() / 1000;
-      appendedURL += `?time=${seconds}`;
-    }
-    /* Fetch library data from API, store inside this.library_data */
+    const rangeDict = {};
+    const listOfRooms = [];
     await fetch(`http://studysmartserver-env.bfmjpq3pm9.us-west-1.elasticbeanstalk.com/studyinfo${appendedURL}`)
       .then(response => response.json())
       .then((data) => {
-        temp = data;
+        for (let i = 0; i < data.Items.length; i += 1) {
+          const time = data.Items[i].time.split(' ')[0];
+          if (time in rangeDict) {
+            rangeDict[time].push(data.Items[i]);
+          } else {
+            rangeDict[time] = [data.Items[i]];
+          }
+          listOfRooms.push(data.Items[i]);
+        }
+        this.setState({
+          availableHill: rangeDict,
+          hillData: listOfRooms,
+          loading: false,
+        });
       });
-    /* Once the request is done, save library data to current state */
-    for (let k = 0; k < temp.Items.length; k += 1) {
-      temp.Items[k].area = 'Hill';
-    }
-    loadHillDataAction(temp.Items);
-    this.sortData();
   }
 
   async getLibraryStudyRooms() {
@@ -458,12 +438,14 @@ class StudyRoomsContainer extends Component {
 
   render() {
     const {
-      hillData, librariesData, availClassroomData, loading
+      hillData, librariesData, availClassroomData, loading, availableHill
     } = this.state;
     const { navigation } = this.props;
+
     return (
       <StudyRoomList
-        // hillDataFound={hillData}
+        hillDataFound={hillData}
+        available={availableHill}
         librariesDataFound={librariesData}
         availClassroomDataFound={availClassroomData}
         filterData={this.filterData}

--- a/app/screens/StudyRoom/StudyRoomsPreview.js
+++ b/app/screens/StudyRoom/StudyRoomsPreview.js
@@ -133,7 +133,6 @@ class StudyRoomsPreview extends Component {
   }
 
   async getHourAvailabilities() {
-    console.log('api')
     let appendedURL = '';
     const { date } = this.props;
     if (date.length > 0) {
@@ -192,8 +191,6 @@ class StudyRoomsPreview extends Component {
   render() {
     const titles = Object.keys(timeRanges);
     const { loading, listOfRooms } = this.state;
-
-    console.log('loading', loading);
 
     return (
       <SafeAreaView style={styles.container}>

--- a/app/screens/StudyRoom/StudyRoomsPreview.js
+++ b/app/screens/StudyRoom/StudyRoomsPreview.js
@@ -3,7 +3,7 @@ import {
   Text, SafeAreaView, TouchableOpacity, StyleSheet, FlatList, Platform, ActivityIndicator
 } from 'react-native';
 import { connect } from 'react-redux';
-import StudyRoomsContainer from './StudyRoomsContainer';
+// import StudyRoomsContainer from './StudyRoomsContainer';
 import TimeRangeCard from '../../components/TimeRangeCard';
 import {
   changeTime, changeDate, changeLocation, loadHillData, loadLibraryData,
@@ -68,104 +68,8 @@ class StudyRoomsPreview extends Component {
     header: () => { }
   }
 
-  constructor() {
-    super();
-    this.state = {
-      available: {},
-      listOfRooms: [],
-      loading: true,
-    };
-  }
-
-  componentDidMount() {
-    const setting = new Date();
-    const { changeTime: changeTimeAction, changeDate: changeDateAction } = this.props;
-    const minutes = setting.getMinutes();
-    if (minutes !== 30 && minutes !== 0) {
-      if (minutes > 30) {
-        setting.setMinutes(60);
-      } else {
-        setting.setMinutes(30);
-      }
-    }
-    let styledTime = setting.toLocaleTimeString();
-    const last2ndChar = styledTime[styledTime.length - 2];
-    const lastChar = styledTime[styledTime.length - 1];
-    if (Platform.OS === 'ios') {
-      styledTime = styledTime.slice(0, -6) + last2ndChar + lastChar;
-    } else {
-      styledTime = styledTime.slice(0, -3);
-      let hour = parseInt(styledTime.substring(0, 2), 10);
-      let hourString = hour.toString();
-      if (hour > 12) {
-        hour -= 12;
-        hourString = hour.toString();
-        styledTime = `${hourString + styledTime.slice(2)}PM`;
-      } else {
-        if (hourString === '0') {
-          hourString = '12';
-        }
-        styledTime = `${hourString + styledTime.slice(2)}AM`;
-      }
-    }
-
-    changeTimeAction(styledTime);
-    let chosen = setting;
-    let dd = chosen.getDate();
-    let mm = chosen.getMonth() + 1; // January is 0!
-    const yyyy = chosen.getFullYear();
-    if (dd < 10) {
-      dd = `0${dd}`;
-    }
-    if (mm < 10) {
-      mm = `0${mm}`;
-    }
-    chosen = `${mm}/${dd}/${yyyy}`;
-    changeDateAction(chosen);
-  }
-
-  componentDidUpdate(prevProps) {
-    const { date } = this.props;
-    // Typical usage (don't forget to compare props):
-    if (date !== prevProps.date) {
-      this.getHourAvailabilities();
-    } 
-  }
-
-  async getHourAvailabilities() {
-    let appendedURL = '';
-    const { date } = this.props;
-    if (date.length > 0) {
-      const month = date.substring(0, 2);
-      const day = date.substring(3, 5);
-      const year = date.substring(date.length - 4);
-      appendedURL = `?date=${year}-${month}-${day}`;
-    }
-    const rangeDict = {};
-    const listOfRooms = [];
-    await fetch(`http://studysmartserver-env.bfmjpq3pm9.us-west-1.elasticbeanstalk.com/studyinfo${appendedURL}`)
-      .then(response => response.json())
-      .then((data) => {
-        for (let i = 0; i < data.Items.length; i += 1) {
-          const time = data.Items[i].time.split(' ')[0];
-          if (time in rangeDict) {
-            rangeDict[time].push(data.Items[i]);
-          } else {
-            rangeDict[time] = [data.Items[i]];
-          }
-          listOfRooms.push(data.Items[i]);
-        }
-        this.setState({
-          available: rangeDict,
-          listOfRooms,
-          loading: false,
-        });
-      });
-  }
-
-
   renderRow(item) {
-    const { available } = this.state;
+    const { available } = this.props;
     const firstHour = available[item];
     const firstHalfHour = available[timeRangesSecondary[item][0]];
     const twoHour = available[timeRangesSecondary[item][1]];
@@ -190,25 +94,16 @@ class StudyRoomsPreview extends Component {
 
   render() {
     const titles = Object.keys(timeRanges);
-    const { loading, listOfRooms } = this.state;
+    const { listOfRooms } = this.props;
 
     return (
       <SafeAreaView style={styles.container}>
-        {
-          loading
-            ?
-            <ActivityIndicator style={styles.animation} size="large" color="#108BF8" />
-            :
-            (
-              <FlatList
-                data={titles}
-                extraData={listOfRooms}
-                renderItem={({ item }) => this.renderRow(item)}
-                keyExtractor={(item, index) => index.toString()}
-              />
-            )
-        }
-
+        <FlatList
+          data={titles}
+          extraData={listOfRooms}
+          renderItem={({ item }) => this.renderRow(item)}
+          keyExtractor={(item, index) => index.toString()}
+        />
       </SafeAreaView>
     );
   }
@@ -222,32 +117,32 @@ const styles = StyleSheet.create({
 });
 
 const mapStateToProps = state => ({
-  time: state.study.time,
-  date: state.study.date,
-  duration: state.study.duration,
-  location: state.study.location,
-  hillData: state.study.hillData,
-  libraryData: state.study.libraryData,
-  unstyledTime: state.study.unstyledTime
+  // time: state.study.time,
+  // date: state.study.date,
+  // duration: state.study.duration,
+  // location: state.study.location,
+  // hillData: state.study.hillData,
+  // libraryData: state.study.libraryData,
+  // unstyledTime: state.study.unstyledTime
 
 });
 
 const mapDispatchToProps = dispatch => ({
-  changeTime: (time) => {
-    dispatch(changeTime(time));
-  },
-  changeDate: (date) => {
-    dispatch(changeDate(date));
-  },
-  changeLocation: (location) => {
-    dispatch(changeLocation(location));
-  },
-  loadHillData: (hillData) => {
-    dispatch(loadHillData(hillData));
-  },
-  loadLibraryData: (libraryData) => {
-    dispatch(loadLibraryData(libraryData));
-  }
+  // changeTime: (time) => {
+  //   dispatch(changeTime(time));
+  // },
+  // changeDate: (date) => {
+  //   dispatch(changeDate(date));
+  // },
+  // changeLocation: (location) => {
+  //   dispatch(changeLocation(location));
+  // },
+  // loadHillData: (hillData) => {
+  //   dispatch(loadHillData(hillData));
+  // },
+  // loadLibraryData: (libraryData) => {
+  //   dispatch(loadLibraryData(libraryData));
+  // }
 });
 
 export default connect(mapStateToProps, mapDispatchToProps)(StudyRoomsPreview);

--- a/app/screens/StudyRoom/StudyRoomsPreview.js
+++ b/app/screens/StudyRoom/StudyRoomsPreview.js
@@ -16,7 +16,7 @@ const timeRanges = {
   '8:00-9:00am': [8, 9],
   '9:00-10:00am': [9, 10],
   '10:00-11:00am': [10, 11],
-  '11:00-12:00pm': [11, 12],
+  '11:00am-12:00pm': [11, 12],
   '12:00-1:00pm': [12, 13],
   '1:00-2:00pm': [13, 14],
   '2:00-3:00pm': [14, 15],
@@ -28,7 +28,7 @@ const timeRanges = {
   '8:00-9:00pm': [20, 21],
   '9:00-10:00pm': [21, 22],
   '10:00-11:00pm': [22, 23],
-  '11:00-12:00am': [23, 0],
+  '11:00pm-midnight': [23, 0],
 };
 
 const timeRangesSecondary = {
@@ -42,8 +42,8 @@ const timeRangesSecondary = {
   '7:00-8:00am': ['7:30-8:30am', '7:00-9:00am', '7:30-9:30am'],
   '8:00-9:00am': ['8:30-9:30am', '8:00-10:00am', '8:30-10:30am'],
   '9:00-10:00am': ['9:30-10:30am', '9:00-11:00am', '9:30-11:30am'],
-  '10:00-11:00am': ['10:30-11:30am', '10:00-12:00pm', '10:30-12:30pm'],
-  '11:00-12:00pm': ['11:30-12:30pm', '11:00-1:00pm', '11:30-1:30pm'],
+  '10:00-11:00am': ['10:30-11:30am', '10:00am-12:00pm', '10:30am-12:30pm'],
+  '11:00am-12:00pm': ['11:30am-12:30pm', '11:00am-1:00pm', '11:30am-1:30pm'],
   '12:00-1:00pm': ['12:30-1:30pm', '12:00-2:00pm', '12:30-2:30pm'],
   '1:00-2:00pm': ['1:30-2:30pm', '1:00-3:00pm', '1:30-3:30pm'],
   '2:00-3:00pm': ['2:30-3:30pm', '2:00-4:00pm', '2:30-4:30pm'],
@@ -54,8 +54,8 @@ const timeRangesSecondary = {
   '7:00-8:00pm': ['7:30-8:30pm', '7:00-9:00pm', '7:30-9:30pm'],
   '8:00-9:00pm': ['8:30-9:30pm', '8:00-10:00pm', '8:30-10:30pm'],
   '9:00-10:00pm': ['9:30-10:30pm', '9:00-11:00pm', '9:30-11:30pm'],
-  '10:00-11:00pm': ['10:30-11:30pm', '10:00-12:00am', '10:30-12:30am'],
-  '11:00-12:00am': ['11:30-12:30am', '11:00-1:00am', '11:30-1:30am']
+  '10:00-11:00pm': ['10:30-11:30pm', '10:00pm-midnight', '10:30pm-12:30am'],
+  '11:00pm-midnight': ['11:30pm-12:30am', '11:00pm-1:00am', '11:30pm-1:30am']
 };
 
 class StudyRoomsPreview extends Component {
@@ -70,7 +70,7 @@ class StudyRoomsPreview extends Component {
     const twoHour = available[timeRangesSecondary[item][1]];
     const twoHalfHour = available[timeRangesSecondary[item][2]];
     const first = firstHour !== undefined ? firstHour : [];
-    const second = second !== undefined ? firstHalfHour : [];
+    const second = firstHalfHour !== undefined ? firstHalfHour : [];
     const third = twoHour !== undefined ? twoHour : [];
     const fourth = twoHalfHour !== undefined ? twoHalfHour : [];
     const total = first.concat(second, third, fourth);

--- a/app/screens/StudyRoom/StudyRoomsPreview.js
+++ b/app/screens/StudyRoom/StudyRoomsPreview.js
@@ -1,13 +1,8 @@
 import React, { Component } from 'react';
 import {
-  Text, SafeAreaView, TouchableOpacity, StyleSheet, FlatList, Platform, ActivityIndicator
+  SafeAreaView, StyleSheet, FlatList,
 } from 'react-native';
-import { connect } from 'react-redux';
-// import StudyRoomsContainer from './StudyRoomsContainer';
 import TimeRangeCard from '../../components/TimeRangeCard';
-import {
-  changeTime, changeDate, changeLocation, loadHillData, loadLibraryData,
-} from '../../Actions/actions';
 
 const timeRanges = {
   '12:00-1:00am': [0, 1],
@@ -116,33 +111,4 @@ const styles = StyleSheet.create({
   },
 });
 
-const mapStateToProps = state => ({
-  // time: state.study.time,
-  // date: state.study.date,
-  // duration: state.study.duration,
-  // location: state.study.location,
-  // hillData: state.study.hillData,
-  // libraryData: state.study.libraryData,
-  // unstyledTime: state.study.unstyledTime
-
-});
-
-const mapDispatchToProps = dispatch => ({
-  // changeTime: (time) => {
-  //   dispatch(changeTime(time));
-  // },
-  // changeDate: (date) => {
-  //   dispatch(changeDate(date));
-  // },
-  // changeLocation: (location) => {
-  //   dispatch(changeLocation(location));
-  // },
-  // loadHillData: (hillData) => {
-  //   dispatch(loadHillData(hillData));
-  // },
-  // loadLibraryData: (libraryData) => {
-  //   dispatch(loadLibraryData(libraryData));
-  // }
-});
-
-export default connect(mapStateToProps, mapDispatchToProps)(StudyRoomsPreview);
+export default StudyRoomsPreview;

--- a/app/screens/StudyRoom/StudyRoomsPreview.js
+++ b/app/screens/StudyRoom/StudyRoomsPreview.js
@@ -1,0 +1,256 @@
+import React, { Component } from 'react';
+import {
+  Text, SafeAreaView, TouchableOpacity, StyleSheet, FlatList, Platform, ActivityIndicator
+} from 'react-native';
+import { connect } from 'react-redux';
+import StudyRoomsContainer from './StudyRoomsContainer';
+import TimeRangeCard from '../../components/TimeRangeCard';
+import {
+  changeTime, changeDate, changeLocation, loadHillData, loadLibraryData,
+} from '../../Actions/actions';
+
+const timeRanges = {
+  '12:00-1:00am': [0, 1],
+  '1:00-2:00am': [1, 2],
+  '2:00-3:00am': [2, 3],
+  '3:00-4:00am': [3, 4],
+  '4:00-5:00am': [4, 5],
+  '5:00-6:00am': [5, 6],
+  '6:00-7:00am': [6, 7],
+  '7:00-8:00am': [7, 8],
+  '8:00-9:00am': [8, 9],
+  '9:00-10:00am': [9, 10],
+  '10:00-11:00am': [10, 11],
+  '11:00-12:00pm': [11, 12],
+  '12:00-1:00pm': [12, 13],
+  '1:00-2:00pm': [13, 14],
+  '2:00-3:00pm': [14, 15],
+  '3:00-4:00pm': [15, 16],
+  '4:00-5:00pm': [16, 17],
+  '5:00-6:00pm': [17, 18],
+  '6:00-7:00pm': [18, 19],
+  '7:00-8:00pm': [19, 20],
+  '8:00-9:00pm': [20, 21],
+  '9:00-10:00pm': [21, 22],
+  '10:00-11:00pm': [22, 23],
+  '11:00-12:00am': [23, 0],
+};
+
+const timeRangesSecondary = {
+  '12:00-1:00am': ['12:30-1:30am', '12:00-2:00am', '12:30-2:30am'],
+  '1:00-2:00am': ['1:30-2:30am', '1:00-3:00am', '1:30-3:30am'],
+  '2:00-3:00am': ['2:30-3:30am', '2:00-4:00am', '2:30-4:30am'],
+  '3:00-4:00am': ['3:30-4:30am', '3:00-5:00am', '3:30-5:30am'],
+  '4:00-5:00am': ['4:30-5:30am', '4:00-6:00am', '4:30-6:30am'],
+  '5:00-6:00am': ['5:30-6:30am', '5:00-7:00am', '5:30-7:30am'],
+  '6:00-7:00am': ['6:30-7:30am', '6:00-8:00am', '6:30-8:30am'],
+  '7:00-8:00am': ['7:30-8:30am', '7:00-9:00am', '7:30-9:30am'],
+  '8:00-9:00am': ['8:30-9:30am', '8:00-10:00am', '8:30-10:30am'],
+  '9:00-10:00am': ['9:30-10:30am', '9:00-11:00am', '9:30-11:30am'],
+  '10:00-11:00am': ['10:30-11:30am', '10:00-12:00pm', '10:30-12:30pm'],
+  '11:00-12:00pm': ['11:30-12:30pm', '11:00-1:00pm', '11:30-1:30pm'],
+  '12:00-1:00pm': ['12:30-1:30pm', '12:00-2:00pm', '12:30-2:30pm'],
+  '1:00-2:00pm': ['1:30-2:30pm', '1:00-3:00pm', '1:30-3:30pm'],
+  '2:00-3:00pm': ['2:30-3:30pm', '2:00-4:00pm', '2:30-4:30pm'],
+  '3:00-4:00pm': ['3:30-4:30pm', '3:00-5:00pm', '3:30-5:30pm'],
+  '4:00-5:00pm': ['4:30-5:30pm', '4:00-6:00pm', '4:30-6:30pm'],
+  '5:00-6:00pm': ['5:30-6:30pm', '5:00-7:00pm', '5:30-7:30pm'],
+  '6:00-7:00pm': ['6:30-7:30pm', '6:00-8:00pm', '6:30-8:30pm'],
+  '7:00-8:00pm': ['7:30-8:30pm', '7:00-9:00pm', '7:30-9:30pm'],
+  '8:00-9:00pm': ['8:30-9:30pm', '8:00-10:00pm', '8:30-10:30pm'],
+  '9:00-10:00pm': ['9:30-10:30pm', '9:00-11:00pm', '9:30-11:30pm'],
+  '10:00-11:00pm': ['10:30-11:30pm', '10:00-12:00am', '10:30-12:30am'],
+  '11:00-12:00am': ['11:30-12:30am', '11:00-1:00am', '11:30-1:30am']
+};
+
+class StudyRoomsPreview extends Component {
+  static navigationOptions = {
+    header: () => { }
+  }
+
+  constructor() {
+    super();
+    this.state = {
+      available: {},
+      listOfRooms: [],
+      loading: true,
+    };
+  }
+
+  componentDidMount() {
+    const setting = new Date();
+    const { changeTime: changeTimeAction, changeDate: changeDateAction } = this.props;
+    const minutes = setting.getMinutes();
+    if (minutes !== 30 && minutes !== 0) {
+      if (minutes > 30) {
+        setting.setMinutes(60);
+      } else {
+        setting.setMinutes(30);
+      }
+    }
+    let styledTime = setting.toLocaleTimeString();
+    const last2ndChar = styledTime[styledTime.length - 2];
+    const lastChar = styledTime[styledTime.length - 1];
+    if (Platform.OS === 'ios') {
+      styledTime = styledTime.slice(0, -6) + last2ndChar + lastChar;
+    } else {
+      styledTime = styledTime.slice(0, -3);
+      let hour = parseInt(styledTime.substring(0, 2), 10);
+      let hourString = hour.toString();
+      if (hour > 12) {
+        hour -= 12;
+        hourString = hour.toString();
+        styledTime = `${hourString + styledTime.slice(2)}PM`;
+      } else {
+        if (hourString === '0') {
+          hourString = '12';
+        }
+        styledTime = `${hourString + styledTime.slice(2)}AM`;
+      }
+    }
+
+    changeTimeAction(styledTime);
+    let chosen = setting;
+    let dd = chosen.getDate();
+    let mm = chosen.getMonth() + 1; // January is 0!
+    const yyyy = chosen.getFullYear();
+    if (dd < 10) {
+      dd = `0${dd}`;
+    }
+    if (mm < 10) {
+      mm = `0${mm}`;
+    }
+    chosen = `${mm}/${dd}/${yyyy}`;
+    changeDateAction(chosen);
+  }
+
+  componentDidUpdate(prevProps) {
+    const { date } = this.props;
+    // Typical usage (don't forget to compare props):
+    if (date !== prevProps.date) {
+      this.getHourAvailabilities();
+    } 
+  }
+
+  async getHourAvailabilities() {
+    console.log('api')
+    let appendedURL = '';
+    const { date } = this.props;
+    if (date.length > 0) {
+      const month = date.substring(0, 2);
+      const day = date.substring(3, 5);
+      const year = date.substring(date.length - 4);
+      appendedURL = `?date=${year}-${month}-${day}`;
+    }
+    const rangeDict = {};
+    const listOfRooms = [];
+    await fetch(`http://studysmartserver-env.bfmjpq3pm9.us-west-1.elasticbeanstalk.com/studyinfo${appendedURL}`)
+      .then(response => response.json())
+      .then((data) => {
+        for (let i = 0; i < data.Items.length; i += 1) {
+          const time = data.Items[i].time.split(' ')[0];
+          if (time in rangeDict) {
+            rangeDict[time].push(data.Items[i]);
+          } else {
+            rangeDict[time] = [data.Items[i]];
+          }
+          listOfRooms.push(data.Items[i]);
+        }
+        this.setState({
+          available: rangeDict,
+          listOfRooms,
+          loading: false,
+        });
+      });
+  }
+
+
+  renderRow(item) {
+    const { available } = this.state;
+    const firstHour = available[item];
+    const firstHalfHour = available[timeRangesSecondary[item][0]];
+    const twoHour = available[timeRangesSecondary[item][1]];
+    const twoHalfHour = available[timeRangesSecondary[item][2]];
+    const first = firstHour !== undefined ? firstHour : [];
+    const second = second !== undefined ? firstHalfHour : [];
+    const third = twoHour !== undefined ? twoHour : [];
+    const fourth = twoHalfHour !== undefined ? twoHalfHour : [];
+    const total = first.concat(second, third, fourth);
+    if (total.length > 0) {
+      return (
+        <TimeRangeCard
+          title={item}
+          available={total}
+          hour={first.concat(third)}
+          half={second.concat(fourth)}
+        />
+      );
+    }
+    return null;
+  }
+
+  render() {
+    const titles = Object.keys(timeRanges);
+    const { loading, listOfRooms } = this.state;
+
+    console.log('loading', loading);
+
+    return (
+      <SafeAreaView style={styles.container}>
+        {
+          loading
+            ?
+            <ActivityIndicator style={styles.animation} size="large" color="#108BF8" />
+            :
+            (
+              <FlatList
+                data={titles}
+                extraData={listOfRooms}
+                renderItem={({ item }) => this.renderRow(item)}
+                keyExtractor={(item, index) => index.toString()}
+              />
+            )
+        }
+
+      </SafeAreaView>
+    );
+  }
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    backgroundColor: 'white'
+  },
+});
+
+const mapStateToProps = state => ({
+  time: state.study.time,
+  date: state.study.date,
+  duration: state.study.duration,
+  location: state.study.location,
+  hillData: state.study.hillData,
+  libraryData: state.study.libraryData,
+  unstyledTime: state.study.unstyledTime
+
+});
+
+const mapDispatchToProps = dispatch => ({
+  changeTime: (time) => {
+    dispatch(changeTime(time));
+  },
+  changeDate: (date) => {
+    dispatch(changeDate(date));
+  },
+  changeLocation: (location) => {
+    dispatch(changeLocation(location));
+  },
+  loadHillData: (hillData) => {
+    dispatch(loadHillData(hillData));
+  },
+  loadLibraryData: (libraryData) => {
+    dispatch(loadLibraryData(libraryData));
+  }
+});
+
+export default connect(mapStateToProps, mapDispatchToProps)(StudyRoomsPreview);

--- a/ios/SS.xcodeproj/project.pbxproj
+++ b/ios/SS.xcodeproj/project.pbxproj
@@ -5,7 +5,6 @@
 	};
 	objectVersion = 46;
 	objects = {
-
 /* Begin PBXBuildFile section */
 		00C302E51ABCBA2D00DB3ED1 /* libRCTActionSheet.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 00C302AC1ABCB8CE00DB3ED1 /* libRCTActionSheet.a */; };
 		00C302E71ABCBA2D00DB3ED1 /* libRCTGeolocation.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 00C302BA1ABCB90400DB3ED1 /* libRCTGeolocation.a */; };

--- a/ios/SS.xcworkspace/xcshareddata/WorkspaceSettings.xcsettings
+++ b/ios/SS.xcworkspace/xcshareddata/WorkspaceSettings.xcsettings
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>PreviewsEnabled</key>
+	<false/>
+</dict>
+</plist>

--- a/package-lock.json
+++ b/package-lock.json
@@ -2677,7 +2677,7 @@
     },
     "ansi-colors": {
       "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-1.1.0.tgz",
+      "resolved": "http://registry.npmjs.org/ansi-colors/-/ansi-colors-1.1.0.tgz",
       "integrity": "sha512-SFKX67auSNoVR38N3L+nvsPjOE0bybKTYbkf5tRvushrAPQ9V75huw0ZxBkKVeRU9kqH3d6HA4xTckbwZ4ixmA==",
       "requires": {
         "ansi-wrap": "^0.1.0"
@@ -3884,7 +3884,7 @@
       "dependencies": {
         "core-js": {
           "version": "1.2.7",
-          "resolved": "https://registry.npmjs.org/core-js/-/core-js-1.2.7.tgz",
+          "resolved": "http://registry.npmjs.org/core-js/-/core-js-1.2.7.tgz",
           "integrity": "sha1-ZSKUwUZR2yj6k70tX/KYOk8IxjY="
         },
         "fbjs": {
@@ -3914,7 +3914,7 @@
       "dependencies": {
         "core-js": {
           "version": "1.2.7",
-          "resolved": "https://registry.npmjs.org/core-js/-/core-js-1.2.7.tgz",
+          "resolved": "http://registry.npmjs.org/core-js/-/core-js-1.2.7.tgz",
           "integrity": "sha1-ZSKUwUZR2yj6k70tX/KYOk8IxjY="
         },
         "fbjs": {
@@ -4812,7 +4812,7 @@
     },
     "external-editor": {
       "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/external-editor/-/external-editor-2.2.0.tgz",
+      "resolved": "http://registry.npmjs.org/external-editor/-/external-editor-2.2.0.tgz",
       "integrity": "sha512-bSn6gvGxKt+b7+6TKEv1ZycHleA7aHhRHyAqJyp5pbUFuYYNIzpZnQDk7AsYckyWdEnTeAnay0aCy2aV6iTk9A==",
       "requires": {
         "chardet": "^0.4.0",
@@ -8746,7 +8746,7 @@
     },
     "load-json-file": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-2.0.0.tgz",
+      "resolved": "http://registry.npmjs.org/load-json-file/-/load-json-file-2.0.0.tgz",
       "integrity": "sha1-eUfkIUmvgNaWy/eXvKq8/h/inKg=",
       "requires": {
         "graceful-fs": "^4.1.2",
@@ -8781,7 +8781,7 @@
     },
     "lodash.isempty": {
       "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/lodash.isempty/-/lodash.isempty-4.4.0.tgz",
+      "resolved": "http://registry.npmjs.org/lodash.isempty/-/lodash.isempty-4.4.0.tgz",
       "integrity": "sha1-b4bL7di+TsmHvpqvM8loTbGzHn4="
     },
     "lodash.memoize": {
@@ -9012,12 +9012,12 @@
         },
         "mime-db": {
           "version": "1.23.0",
-          "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.23.0.tgz",
+          "resolved": "http://registry.npmjs.org/mime-db/-/mime-db-1.23.0.tgz",
           "integrity": "sha1-oxtAcK2uon1zLqMzdApk0OyaZlk="
         },
         "mime-types": {
           "version": "2.1.11",
-          "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.11.tgz",
+          "resolved": "http://registry.npmjs.org/mime-types/-/mime-types-2.1.11.tgz",
           "integrity": "sha1-wlnEcb2oCKhdbNGTtDCl+uRHOzw=",
           "requires": {
             "mime-db": "~1.23.0"
@@ -9317,7 +9317,7 @@
     },
     "minimist": {
       "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+      "resolved": "http://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
       "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
     },
     "mixin-deep": {
@@ -9341,7 +9341,7 @@
     },
     "mkdirp": {
       "version": "0.5.1",
-      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+      "resolved": "http://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
       "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
       "requires": {
         "minimist": "0.0.8"
@@ -9349,7 +9349,7 @@
       "dependencies": {
         "minimist": {
           "version": "0.0.8",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+          "resolved": "http://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
           "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
         }
       }
@@ -9512,7 +9512,7 @@
     },
     "npmlog": {
       "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-2.0.4.tgz",
+      "resolved": "http://registry.npmjs.org/npmlog/-/npmlog-2.0.4.tgz",
       "integrity": "sha1-mLUlMPJRTKkNCexbIsiEZyI3VpI=",
       "requires": {
         "ansi": "~0.3.1",
@@ -9723,7 +9723,7 @@
         },
         "chalk": {
           "version": "1.1.3",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+          "resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
           "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
           "requires": {
             "ansi-styles": "^2.2.1",
@@ -9755,7 +9755,7 @@
         },
         "node-fetch": {
           "version": "1.6.3",
-          "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-1.6.3.tgz",
+          "resolved": "http://registry.npmjs.org/node-fetch/-/node-fetch-1.6.3.tgz",
           "integrity": "sha1-3CNO3WSJmC1Y6PDbT2lQKavNjAQ=",
           "requires": {
             "encoding": "^0.1.11",
@@ -9764,7 +9764,7 @@
         },
         "opn": {
           "version": "4.0.2",
-          "resolved": "https://registry.npmjs.org/opn/-/opn-4.0.2.tgz",
+          "resolved": "http://registry.npmjs.org/opn/-/opn-4.0.2.tgz",
           "integrity": "sha1-erwi5kTf9jsKltWrfyeQwPAavJU=",
           "requires": {
             "object-assign": "^4.0.1",
@@ -9775,7 +9775,7 @@
     },
     "opn": {
       "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/opn/-/opn-3.0.3.tgz",
+      "resolved": "http://registry.npmjs.org/opn/-/opn-3.0.3.tgz",
       "integrity": "sha1-ttmec5n3jWXDuq/+8fsojpuFJDo=",
       "requires": {
         "object-assign": "^4.0.1"
@@ -9792,7 +9792,7 @@
       "dependencies": {
         "minimist": {
           "version": "0.0.10",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz",
+          "resolved": "http://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz",
           "integrity": "sha1-3j+YVD2/lggr5IrRoMfNqDYwHc8="
         },
         "wordwrap": {
@@ -10023,7 +10023,7 @@
     },
     "pify": {
       "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+      "resolved": "http://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
       "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw="
     },
     "pinkie": {
@@ -10141,7 +10141,7 @@
         },
         "kind-of": {
           "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-1.1.0.tgz",
+          "resolved": "http://registry.npmjs.org/kind-of/-/kind-of-1.1.0.tgz",
           "integrity": "sha1-FAo9LUGjbS78+pN3tiwk+ElaXEQ="
         }
       }
@@ -10455,7 +10455,7 @@
     },
     "react-native-elements": {
       "version": "0.19.1",
-      "resolved": "https://registry.npmjs.org/react-native-elements/-/react-native-elements-0.19.1.tgz",
+      "resolved": "http://registry.npmjs.org/react-native-elements/-/react-native-elements-0.19.1.tgz",
       "integrity": "sha1-+Stp2GShUCFdAfgf48UqnK2oPkU=",
       "requires": {
         "lodash.isempty": "^4.4.0",
@@ -10518,7 +10518,7 @@
     },
     "react-native-tab-view": {
       "version": "0.0.77",
-      "resolved": "https://registry.npmjs.org/react-native-tab-view/-/react-native-tab-view-0.0.77.tgz",
+      "resolved": "http://registry.npmjs.org/react-native-tab-view/-/react-native-tab-view-0.0.77.tgz",
       "integrity": "sha512-9vjD4Ly1Zlum1Y4g23ODpi/F3gYIUIsKWrsZO/Oh5cuX1eiB1DRVn11nY1z+j/hsQfhfyW6nDlmySyDvYQvYCA==",
       "requires": {
         "prop-types": "^15.6.0"
@@ -10807,7 +10807,7 @@
     },
     "readable-stream": {
       "version": "2.3.6",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+      "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
       "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
       "requires": {
         "core-util-is": "~1.0.0",
@@ -11106,7 +11106,7 @@
     },
     "safe-regex": {
       "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/safe-regex/-/safe-regex-1.1.0.tgz",
+      "resolved": "http://registry.npmjs.org/safe-regex/-/safe-regex-1.1.0.tgz",
       "integrity": "sha1-QKNmnzsHfR6UPURinhV91IAjvy4=",
       "requires": {
         "ret": "~0.1.10"
@@ -11432,7 +11432,7 @@
     },
     "serialize-error": {
       "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/serialize-error/-/serialize-error-2.1.0.tgz",
+      "resolved": "http://registry.npmjs.org/serialize-error/-/serialize-error-2.1.0.tgz",
       "integrity": "sha1-ULZ51WNc34Rme9yOWa9OW4HV9go="
     },
     "serve-static": {
@@ -11897,7 +11897,7 @@
     },
     "strip-ansi": {
       "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+      "resolved": "http://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
       "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
       "requires": {
         "ansi-regex": "^2.0.0"
@@ -11910,7 +11910,7 @@
     },
     "strip-eof": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
+      "resolved": "http://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
       "integrity": "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8="
     },
     "strip-json-comments": {
@@ -11986,7 +11986,7 @@
       "dependencies": {
         "rimraf": {
           "version": "2.2.8",
-          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.2.8.tgz",
+          "resolved": "http://registry.npmjs.org/rimraf/-/rimraf-2.2.8.tgz",
           "integrity": "sha1-5Dm+Kq7jJzIZUnMPmaiSnk/FBYI="
         }
       }
@@ -12115,7 +12115,7 @@
     },
     "through": {
       "version": "2.3.8",
-      "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
+      "resolved": "http://registry.npmjs.org/through/-/through-2.3.8.tgz",
       "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU="
     },
     "through2": {
@@ -12521,7 +12521,7 @@
     },
     "wrap-ansi": {
       "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
+      "resolved": "http://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
       "integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
       "requires": {
         "string-width": "^1.0.1",
@@ -12598,7 +12598,7 @@
     },
     "xmlbuilder": {
       "version": "9.0.7",
-      "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-9.0.7.tgz",
+      "resolved": "http://registry.npmjs.org/xmlbuilder/-/xmlbuilder-9.0.7.tgz",
       "integrity": "sha1-Ey7mPS7FVlxVfiD0wi35rKaGsQ0="
     },
     "xmldoc": {


### PR DESCRIPTION
This PR focuses on implementing the most basic functionality of better booking flow for the Hill View.

Please test me:
1. Pull this branch!
2. Build on iOS and Android and run on both! 
3. The app will open to the new hill screen automatically, play around with the listings, changing dates, and clicking on a time to view the rooms. 
4. Ensure that the app properly opens the page to book the room.
5. Check edge cases such as 11am-12pm and 11pm-midnight

This has been tested successfully on:
- iPhone 11
- Generic Android

Future UI updates not yet implemented (and won't be in this PR):
- Hill View better booking flow should display calendar icon instead of clock
> Should just be in StudyRoomHeader.js. Use prop to determine which tab we are on, if it is Hill tab render Image of calendarIcon instead of clockIcon.
- Hill view better booking flow when clicking modal for date change should not display time, just date
> Should just be in StudyRoomModal.js `render()` method. We already have a prop `currentLocation` so if `currentLocation !== 'Hill'` then render `<Date Time Picker mode="time" />`.
- Upon selecting a time period for room selection, the title of the page should update to reflect the selection
> Should be in StudyRoomReserve.js but may need to pass more props in from TimeRangeCard.js
- Ability to search for rooms within the time results